### PR TITLE
Fix to make tile work in XLR 7.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 
-version = "3.0.3"
+version = "3.0.4"
 
 xlDocker {
   compileImage = 'xebialabs/xlr_dev_compile'

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -113,6 +113,7 @@
         <property name="uri" hidden="true" default="include/ISPWServicesTile/ispw-tile-view.html" />
         <property name="title" description="Tile title" default="ISPW Services Summary"/>
         <property name="detailsUri" hidden="true" default="include/ISPWServicesTile/ispw-tile-details.html" />
+        <property name="embedded" kind="boolean" hidden="true" default="true" required="false"/>  <!-- XLR 7.0.0 compatibility -->
 
         <property category="input" name="action" required="true" default="deploy" description="ISPW Action to show (Possible values are Deploy,Promote and CreateRelease)" />
     </type>


### PR DESCRIPTION
We changed the tile plugin system from 6.2 to 7.0. Tile plugins are now properly documented so users can write their own. They run inside an iframe by default. The old-style plugins had access to our GUI (and had the power to take down the system). They still work, but need to set an additional hidden property embedded=true.